### PR TITLE
missing cstdint

### DIFF
--- a/src/definitions.h
+++ b/src/definitions.h
@@ -39,6 +39,7 @@
 #include <cmath>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 #ifdef _WIN32
 #ifndef NOMINMAX


### PR DESCRIPTION
older versions of gcc would include it implicitly in one of the other includes, but newer versions of gcc like 13.2.0 does not, leading to errors like

```
In file included from /home/hans/projects/POTCP/forgottenserver/src/otpch.h:23,
                 from /home/hans/projects/POTCP/forgottenserver/build/cotire/tfs_CXX_prefix.cxx:4,
                 from /home/hans/projects/POTCP/forgottenserver/build/cotire/tfs_CXX_prefix.hxx:4:
/home/hans/projects/POTCP/forgottenserver/src/definitions.h:78:31: error: ‘uint32_t’ was not declared in this scope
   78 | typedef std::vector<std::pair<uint32_t, uint32_t>> IPList;
```