### PR TITLE
read_timeout modern gcc compatibility

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -116,7 +116,7 @@ void Connection::accept()
 {
 	std::lock_guard<std::recursive_mutex> lockClass(connectionLock);
 	try {
-		readTimer.expires_from_now(boost::posix_time::seconds(Connection::read_timeout));
+		readTimer.expires_from_now(boost::posix_time::seconds(static_cast<int>(Connection::read_timeout)));
 		readTimer.async_wait(std::bind(&Connection::handleTimeout, std::weak_ptr<Connection>(shared_from_this()), std::placeholders::_1));
 
 		// Read size of the first packet
@@ -156,7 +156,7 @@ void Connection::parseHeader(const boost::system::error_code& error)
 	}
 
 	try {
-		readTimer.expires_from_now(boost::posix_time::seconds(Connection::read_timeout));
+		readTimer.expires_from_now(boost::posix_time::seconds(static_cast<int>(Connection::read_timeout)));
 		readTimer.async_wait(std::bind(&Connection::handleTimeout, std::weak_ptr<Connection>(shared_from_this()),
 		                                    std::placeholders::_1));
 
@@ -204,7 +204,7 @@ void Connection::parsePacket(const boost::system::error_code& error)
 	}
 
 	try {
-		readTimer.expires_from_now(boost::posix_time::seconds(Connection::read_timeout));
+		readTimer.expires_from_now(boost::posix_time::seconds(static_cast<int>(Connection::read_timeout)));
 		readTimer.async_wait(std::bind(&Connection::handleTimeout, std::weak_ptr<Connection>(shared_from_this()),
 		                                    std::placeholders::_1));
 
@@ -236,7 +236,7 @@ void Connection::internalSend(const OutputMessage_ptr& msg)
 {
 	protocol->onSendMessage(msg);
 	try {
-		writeTimer.expires_from_now(boost::posix_time::seconds(Connection::write_timeout));
+		writeTimer.expires_from_now(boost::posix_time::seconds(static_cast<int>(Connection::write_timeout)));
 		writeTimer.async_wait(std::bind(&Connection::handleTimeout, std::weak_ptr<Connection>(shared_from_this()),
 		                                     std::placeholders::_1));
 

--- a/src/connection.h
+++ b/src/connection.h
@@ -63,8 +63,8 @@ class Connection : public std::enable_shared_from_this<Connection>
 		Connection(const Connection&) = delete;
 		Connection& operator=(const Connection&) = delete;
 
-		static const int write_timeout = 30;
-		static const int read_timeout = 30;
+		enum { write_timeout = 30 };
+		enum { read_timeout = 30 };
 
 		enum ConnectionState_t {
 			CONNECTION_STATE_OPEN,

--- a/src/connection.h
+++ b/src/connection.h
@@ -63,8 +63,8 @@ class Connection : public std::enable_shared_from_this<Connection>
 		Connection(const Connection&) = delete;
 		Connection& operator=(const Connection&) = delete;
 
-		enum { write_timeout = 30 };
-		enum { read_timeout = 30 };
+		static const int write_timeout = 30;
+		static const int read_timeout = 30;
 
 		enum ConnectionState_t {
 			CONNECTION_STATE_OPEN,


### PR DESCRIPTION
read_timeout modern gcc compatibility

... sounds really stupid and i don't quite understand it myself, but old versions of gcc could deduce that write_timeout and read_timeout were integral at compile time, but it seems modern gcc (at least 13.2.0) cannot.. this fixes
```
[ 16%] Building CXX object CMakeFiles/tfs.dir/src/connection.cpp.o /home/hans/projects/POTCP/forgottenserver/src/connection.cpp: In member function ‘void Connection::accept()’: /home/hans/projects/POTCP/forgottenserver/src/connection.cpp:119:95: error: no matching function for call to ‘boost::posix_time::seconds::seconds(Connection::<unnamed enum>)’
  119 |                 readTimer.expires_from_now(boost::posix_time::seconds(Connection::read_timeout));
      |                                                                                               ^
In file included from /usr/include/boost/date_time/posix_time/posix_time_types.hpp:16,
                 from /usr/include/boost/asio/time_traits.hpp:23,
                 from /usr/include/boost/asio/detail/timer_queue_ptime.hpp:22,
                 from /usr/include/boost/asio/detail/deadline_timer_service.hpp:31,
                 from /usr/include/boost/asio/basic_deadline_timer.hpp:25,
                 from /usr/include/boost/asio.hpp:33,
                 from /home/hans/projects/POTCP/forgottenserver/src/otpch.h:42,
                 from /home/hans/projects/POTCP/forgottenserver/build/cotire/tfs_CXX_prefix.cxx:4,
                 from /home/hans/projects/POTCP/forgottenserver/build/cotire/tfs_CXX_prefix.hxx:4:
/usr/include/boost/date_time/posix_time/posix_time_duration.hpp:57:38: note: candidate: ‘template<class T> boost::posix_time::seconds::seconds(const T&, typename boost::enable_if<boost::is_integral<T>, void>::type*)’
   57 |       BOOST_CXX14_CONSTEXPR explicit seconds(T const& s,
      |                                      ^~~~~~~

```