### PR TITLE
make OutputMessageAllocator compatible with modern gcc

### DIFF
--- a/src/lockfree.h
+++ b/src/lockfree.h
@@ -26,6 +26,7 @@ template <typename T, size_t CAPACITY>
 class LockfreePoolingAllocator : public std::allocator<T>
 {
 	public:
+        LockfreePoolingAllocator() = default;
 		template <typename U>
 		explicit LockfreePoolingAllocator(const U&) {}
 		typedef T value_type;


### PR DESCRIPTION
Needed some adjustments to be compatible with modern gcc's std::allocate_shared


snippet of related errors on gcc 13.2:
```
hans@DESKTOP-EE15SLU:~/projects/POTCP/forgottenserver/build$ make [  1%] Building CXX object CMakeFiles/tfs.dir/src/outputmessage.cpp.o In file included from /usr/include/c++/13/ext/alloc_traits.h:34,
                 from /usr/include/c++/13/bits/basic_string.h:39,
                 from /usr/include/c++/13/string:54,
                 from /home/hans/projects/POTCP/forgottenserver/src/definitions.h:40,
                 from /home/hans/projects/POTCP/forgottenserver/src/otpch.h:23,
                 from /home/hans/projects/POTCP/forgottenserver/build/cotire/tfs_CXX_prefix.cxx:4,
                 from /home/hans/projects/POTCP/forgottenserver/build/cotire/tfs_CXX_prefix.hxx:4:
/usr/include/c++/13/bits/alloc_traits.h: In instantiation of ‘struct std::__allocator_traits_base::__rebind<OutputMessageAllocator, std::_Sp_counted_ptr_inplace<OutputMessage, OutputMessageAllocator, __gnu_cxx::_S_atomic>, void>’:
/usr/include/c++/13/bits/alloc_traits.h:94:11:   required by substitution of ‘template<class _Alloc, class _Up> using std::__alloc_rebind = typename std::__allocator_traits_base::__rebind<_Alloc, _Up>::type [with _Alloc = OutputMessageAllocator; _Up = std::_Sp_counted_ptr_inplace<OutputMessage, OutputMessageAllocator, __gnu_cxx::_S_atomic>]’
/usr/include/c++/13/bits/shared_ptr_base.h:595:13:   required from ‘class std::_Sp_counted_ptr_inplace<OutputMessage, OutputMessageAllocator, __gnu_cxx::_S_atomic>’
/usr/include/c++/13/bits/shared_ptr_base.h:968:43:   required from ‘std::__shared_count<_Lp>::__shared_count(_Tp*&, std::_Sp_alloc_shared_tag<_Alloc>, _Args&& ...) [with _Tp = OutputMessage; _Alloc = OutputMessageAllocator; _Args = {}; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’
/usr/include/c++/13/bits/shared_ptr_base.h:1712:14:   required from ‘std::__shared_ptr<_Tp, _Lp>::__shared_ptr(std::_Sp_alloc_shared_tag<_Tp>, _Args&& ...) [with _Alloc = OutputMessageAllocator; _Args = {}; _Tp = OutputMessage; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’
/usr/include/c++/13/bits/shared_ptr.h:464:59:   required from ‘std::shared_ptr<_Tp>::shared_ptr(std::_Sp_alloc_shared_tag<_Tp>, _Args&& ...) [with _Alloc = OutputMessageAllocator; _Args = {}; _Tp = OutputMessage]’
/usr/include/c++/13/bits/shared_ptr.h:992:14:   required from ‘std::shared_ptr<typename std::enable_if<(! std::is_array< <template-parameter-1-1> >::value), _Tp>::type> std::allocate_shared(const _Alloc&, _Args&& ...) [with _Tp = OutputMessage; _Alloc = OutputMessageAllocator; _Args = {}; typename enable_if<(! is_array< <template-parameter-1-1> >::value), _Tp>::type = OutputMessage]’
/home/hans/projects/POTCP/forgottenserver/src/outputmessage.cpp:81:44:   required from here
/usr/include/c++/13/bits/alloc_traits.h:70:31: error: static assertion failed: allocator_traits<A>::rebind_alloc<A::value_type> must be A
   70 |                         _Tp>::value,
      |                               ^~~~~
/usr/include/c++/13/bits/alloc_traits.h:70:31: note: ‘std::integral_constant<bool, false>::value’ evaluates to false
make[2]: *** [CMakeFiles/tfs.dir/build.make:750: CMakeFiles/tfs.dir/src/outputmessage.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:86: CMakeFiles/tfs.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```