### PR TITLE
make formatDate compatible with modern gcc

### DIFF
--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -322,13 +322,14 @@ std::string formatDate(time_t time)
 		return std::string();
 	}
 
-	char buffer[20];
+	char buffer[72]; // >src/tools.cpp:326:26: note: ‘sprintf’ output between 20 and 72 bytes into a destination of size 30
 	int res = sprintf(buffer, "%02d/%02d/%04d %02d:%02d:%02d", tms->tm_mday, tms->tm_mon + 1, tms->tm_year + 1900, tms->tm_hour, tms->tm_min, tms->tm_sec);
 	if (res < 0) {
 		return std::string();
 	}
-	return std::string(buffer, 19);
+	return std::string(buffer, ::strlen(buffer);
 }
+
 
 std::string formatDateShort(time_t time)
 {

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -327,7 +327,7 @@ std::string formatDate(time_t time)
 	if (res < 0) {
 		return std::string();
 	}
-	return std::string(buffer, ::strlen(buffer);
+	return std::string(buffer, ::strlen(buffer));
 }
 
 


### PR DESCRIPTION
I think part of the problem is that tm_year can in theory be INT_MAX = 9,223,372,036,854,775,807  , for more info see https://en.wikipedia.org/wiki/Year_2038_problem


related error:
```
[  1%] Building CXX object CMakeFiles/tfs.dir/src/tools.cpp.o /home/hans/projects/POTCP/forgottenserver/src/tools.cpp: In function ‘std::string formatDate(time_t)’: /home/hans/projects/POTCP/forgottenserver/src/tools.cpp:326:56: error: ‘%02d’ directive writing between 2 and 11 bytes into a region of size between 0 and 16 [-Werror=format-overflow=]
  326 |         int res = sprintf(buffer, "%02d/%02d/%04d %02d:%02d:%02d", tms->tm_mday, tms->tm_mon + 1, tms->tm_year + 1900, tms->tm_hour, tms->tm_min, tms->tm_sec);
      |                                                        ^~~~
/home/hans/projects/POTCP/forgottenserver/src/tools.cpp:326:26: note: ‘sprintf’ output between 20 and 72 bytes into a destination of size 30
  326 |         int res = sprintf(buffer, "%02d/%02d/%04d %02d:%02d:%02d", tms->tm_mday, tms->tm_mon + 1, tms->tm_year + 1900, tms->tm_hour, tms->tm_min, tms->tm_sec);
```